### PR TITLE
Implement a rough reference section

### DIFF
--- a/static/source/_plugin_doc.slim
+++ b/static/source/_plugin_doc.slim
@@ -1,0 +1,44 @@
+article
+  /  TODO: Name + version in metadata
+  / h3 == plugin["gem"].gsub("danger-", "") + " <span>#{plugin["gem"]["version"]}</span>"
+  h3 == plugin["name"]
+  == markdown_h(plugin["body_md"])
+
+  h3 Reference
+  h4 Attributes
+  - for attribute in plugin["attributes"]
+    .fake_code
+       == markdown_h(attribute.values.first["write"]["body_md"])
+    code == attribute.keys.first
+
+  h4 Methods
+  - for method in plugin["methods"]
+    .fake_code
+       == markdown_h(method["body_md"])
+    code == method["name"]
+
+article
+  h3 Examples
+  - for example in plugin["example_code"]
+    h4 == example["title"]
+    code
+      blockquote == example["text"].lines.join("<br>")
+
+  / TODO: Gem name
+  / h3 How to Install
+  / markdown:
+  /   Include `gem "#{plugin["gem"]["name"]}"` in your project’s Gemfile. Then run `bundle`.
+
+  /   Then inside your Dangerfile, you can access the plugin's API via `#{plugin["instance_name"]}`.
+  
+  - if external == false
+    h3 Tags
+    code == plugin["tags"].join(" ")
+
+    - if plugin["see"].empty? == false
+      h3 See in Action
+      ul
+        - for link in plugin["see"]
+          li
+            a href="https://github.com/#{link}" == link
+.clearfix

--- a/static/source/index.html.slim
+++ b/static/source/index.html.slim
@@ -72,49 +72,8 @@ section
     .clearfix
 
     - for plugin in JSON.parse(File.read("json_data/plugins.json"))
-      article
-        /  TODO: Name + version in metadata
-        / h3 == plugin["gem"].gsub("danger-", "") + " <span>#{plugin["gem"]["version"]}</span>"
-        h3 == plugin["name"]
-        == markdown_h(plugin["body_md"])
+     == partial(:plugin_doc, locals: { plugin: plugin, external: true })
 
-        h3 Reference
-        h4 Attributes
-        - for attribute in plugin["attributes"]
-          .fake_code
-             == markdown_h(attribute.values.first["write"]["body_md"])
-          code == attribute.keys.first
-
-        h4 Methods
-        - for method in plugin["methods"]
-          .fake_code
-             == markdown_h(method["body_md"])
-          code == method["name"]
-
-      article
-        h3 Examples
-        - for example in plugin["example_code"]
-          h4 == example["title"]
-          code
-            blockquote == example["text"].lines.join("<br>")
-
-        / TODO: Gem name
-        / h3 How to Install
-        / markdown:
-        /   Include `gem "#{plugin["gem"]["name"]}"` in your project’s Gemfile. Then run `bundle`.
-
-        /   Then inside your Dangerfile, you can access the plugin's API via `#{plugin["instance_name"]}`.
-
-        h3 Tags
-        code == plugin["tags"].join(" ")
-
-        - if plugin["see"].empty? == false
-          h3 See in Action
-          ul
-            - for link in plugin["see"]
-              li
-                a href="https://github.com/#{link}" == link
-      .clearfix
 
   section
     h2

--- a/static/source/reference.html.slim
+++ b/static/source/reference.html.slim
@@ -6,6 +6,6 @@ title: Danger - Reference
 section
   h2
     span Reference
-  article
-    p Sorry Nothing Here yet
-  .clearfix
+ 
+  - for plugin in JSON.parse(File.read("json_data/core.json"))
+     == partial(:plugin_doc, locals: { plugin: plugin, external: false })


### PR DESCRIPTION
Moves the plugin renderer into a partial, lets Danger core use the plugin reference code to make a reference for the API.

![screen shot 2016-07-04 at 7 39 59 pm](https://cloud.githubusercontent.com/assets/49038/16570962/3a5023f4-421f-11e6-9c96-1078f6696130.png)
