### PR TITLE
Fix json webhook parsing routing for danger.systems 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/danger/danger.git
-  revision: b8b9f357cc35460b01c0aa07a849b7323cbbaba4
+  revision: 1824f1d97009ada598c1e4ca85cedf3be6b8f972
   branch: master
   specs:
-    danger (0.8.4)
+    danger (0.8.5)
       claide (~> 1.0)
       colored (~> 1.2)
       cork (~> 0.1)

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ task :generate do
 
         # Get the name'd gems out of bundler, then convert them into useful search metadata
         gem_paths = specs.select { |spec| spec.is_a? Bundler::EndpointSpecification }.map { |endpoint| endpoint.gem_dir + '/' + endpoint.name + '.gemspec' }
-        real_gems = gem_paths.map { |path| Gem::Specification.load path }
+        real_gems = gem_paths.flat_map { |path| Gem::Specification.load path }
         plugin_metadata = real_gems.map do |gem|
           {
             gem: gem.name,

--- a/webhooks/server.rb
+++ b/webhooks/server.rb
@@ -11,7 +11,7 @@ class App < Sinatra::Base
     payload_body = request.body.read
     hook = JSON.parse(payload_body)
 
-    # Gice an OK message when it's being set up
+    # Give an OK message when it's being set up
     return "OK" if hook["hook"] && hook["hook"]["type"] == "Repository"
 
     # Grab our list of plugins
@@ -20,13 +20,13 @@ class App < Sinatra::Base
     plugin_urls = plugins['plugins'].map { |plugin| plugin['url'] }
 
     # Allow new tags on Danger/Danger to trigger updates
-    plugin_urls << "https://github.com/danger/danger/"
+    plugin_urls << "https://github.com/danger/danger"
 
     # 403 if it's not a tag create
     halt 403 unless hook['ref_type'] == 'tag'
 
     # 403 if the webhook's repo isn't in the plugins search JSON
-    source = hook['html_url']
+    source = hook['repository']['html_url']
     halt 403 unless plugin_urls.include? source
 
     travis_token = ENV['TRAVIS_TOKEN']


### PR DESCRIPTION
We were using the wrong JSON path for the source URL of the repo, and I added an extra `/` to Danger's one.