### PR TITLE
Prepare for 0.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/danger/danger.git
-  revision: 62df66adfa1fcbe284fb34c57d82872912769a79
+  revision: c65e0bbbcb7e92f05df8bb568b98e55f2c57d3a0
   branch: master
   specs:
     danger (0.9.0)

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ task :generate do
   danger_core_plugins = Dir.glob(danger_gem.gem_dir + "/lib/danger/danger_core/plugins/*.rb")
 
   # Document them, move them into a nice JSON file
-  output = `bundle exec danger plugins lint #{danger_core_plugins.join(' ')}`
+  output = `bundle exec danger plugins json #{danger_core_plugins.join(' ')}`
   File.write('static/json_data/core.json', output)
   puts 'Generated core API metadata'
 
@@ -20,7 +20,7 @@ task :generate do
   plugins = JSON.parse(File.read('plugins.json'))
 
   # Generate the Website's plugin docm, by just passing in the gem names
-  output = `bundle exec danger plugins lint #{plugins.join(' ')}`
+  output = `bundle exec danger plugins json #{plugins.join(' ')}`
   File.write('static/json_data/plugins.json', output)
   puts 'Generated plugin metadata'
 


### PR DESCRIPTION
Uses `danger plugins json` instead of `danger plugins lint`.