### PR TITLE
Simplify the rakefile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,15 @@
 GIT
   remote: https://github.com/danger/danger.git
-  revision: c65e0bbbcb7e92f05df8bb568b98e55f2c57d3a0
+  revision: 4eee84145df46dff5c95f7616b4122f5938f5a96
   branch: master
   specs:
-    danger (0.9.0)
+    danger (0.9.1)
       claide (~> 1.0)
       claide-plugins (~> 0.9)
       colored (~> 1.2)
       cork (~> 0.1)
       faraday (~> 0)
+      faraday-http-cache (~> 1.0)
       git (~> 1)
       octokit (~> 4.2)
       redcarpet (~> 3.3)
@@ -17,7 +18,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
+    activesupport (4.2.7)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -51,6 +52,8 @@ GEM
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.0)
+      faraday (~> 0.8)
     fast_blank (1.0.0)
     fastimage (2.0.0)
       addressable (~> 2)
@@ -111,12 +114,13 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.9.0)
     multipart-post (2.0.0)
     nap (1.1.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
     open4 (1.3.4)
@@ -127,6 +131,7 @@ GEM
     padrino-support (0.13.2)
       activesupport (>= 3.1)
     parallel (1.9.0)
+    pkg-config (1.1.7)
     posix-spawn (0.3.11)
     pry (0.10.4)
       coderay (~> 1.1.0)

--- a/plugins-search-generated.json
+++ b/plugins-search-generated.json
@@ -1,1 +1,1 @@
-{"plugins":[{"gem":"danger-prose","authors":"David Grandinetti, Orta Therox","url":"https://github.com/dbgrandi/danger-prose","description":"A danger plugin for working with bodies of markdown prose.","license":"MIT","version":"2.0.0"}]}
+{"plugins":[{"gem":"danger-prose","authors":"David Grandinetti, Orta Therox","url":"https://github.com/dbgrandi/danger-prose","description":"A danger plugin for working with bodies of markdown prose.","license":"MIT","version":"2.0.1"}]}


### PR DESCRIPTION
Using the Bundler ruby API was more trouble than it was worth once I started trying gems that I don't control through the system. So I've moved it to a dead simple "make a gemfile, run bundle install, pull out the specs" instead.