### PR TITLE
Updates the example Dangerfiles

### DIFF
--- a/example_oss_dangerfiles.json
+++ b/example_oss_dangerfiles.json
@@ -1,1 +1,1 @@
-["moya/moya", "artsy/artsy.github.io", "artsy/energy", "artsy/eigen", "fastlane/fastlane", "danger/danger", "cocoapods/cocoapods", "samdmarshall/pyconfig#develop", "samdmarshall/danger"]
+["moya/moya", "artsy/artsy.github.io", "artsy/energy", "artsy/eigen", "danger/danger", "cocoapods/cocoapods", "samdmarshall/pyconfig#develop", "samdmarshall/danger"]

--- a/static/source/examples.yml
+++ b/static/source/examples.yml
@@ -37,7 +37,7 @@
 
 - title: "Highlight build artifacts"
   id: "artifacts"
-  repos: "samdmarshall/pyconfig#develop, artsy/eigen, fastlane/fastlane"
+  repos: "samdmarshall/pyconfig#develop, artsy/eigen"
   code: |
     username = ENV['CIRCLE_PROJECT_USERNAME']
     project_name = ENV['CIRCLE_PROJECT_REPONAME']
@@ -49,7 +49,7 @@
 
 - title: "Special case special files"
   id: "special"
-  repos: "samdmarshall/pyconfig#develop, artsy/eigen, fastlane/fastlane"
+  repos: "samdmarshall/pyconfig#develop, artsy/eigen"
   code: |
     # Did you make analytics changes? Well you should also include a change to our analytics spec
     made_analytics_changes = modified_files.include?("/Artsy/App/ARAppDelegate+Analytics.m")

--- a/static/source/examples.yml
+++ b/static/source/examples.yml
@@ -37,7 +37,7 @@
 
 - title: "Highlight build artifacts"
   id: "artifacts"
-  repos: "samdmarshall/pyconfig#develop, artsy/eigen"
+  repos: "samdmarshall/danger, artsy/eigen"
   code: |
     username = ENV['CIRCLE_PROJECT_USERNAME']
     project_name = ENV['CIRCLE_PROJECT_REPONAME']
@@ -49,7 +49,7 @@
 
 - title: "Special case special files"
   id: "special"
-  repos: "samdmarshall/pyconfig#develop, artsy/eigen"
+  repos: "samdmarshall/danger, artsy/eigen"
   code: |
     # Did you make analytics changes? Well you should also include a change to our analytics spec
     made_analytics_changes = modified_files.include?("/Artsy/App/ARAppDelegate+Analytics.m")


### PR DESCRIPTION
Removes the fastlane ones ATM, and moves the smaller pyconfig references to refer to the global Danger instead of the specific one, as the work is being done there now.