### PR TITLE
Specify the GitHub bot requires "Write" access

### DIFF
--- a/static/source/guides/getting_started.html.slim
+++ b/static/source/guides/getting_started.html.slim
@@ -70,7 +70,7 @@ section.guide
 
       ##### Closed Source Projects
 
-      Add the bot to repo, or to your organization. Note that you _should not_ re-use this bot for OSS projects.
+      Add the bot to repo, or to your organization. The bot requires permission level "Write" to be able to set a PR's status. Note that you _should not_ re-use this bot for OSS projects.
 
       ### Setting up an Access Token
 


### PR DESCRIPTION
If set to "Read", the build will fail with a message akin to the following:

```
Danger has failed this build. 
Found 1 error and I don't have write access to the PR set a PR status.
```

I do wonder if this is different for OSS projects, and whether [getting_started.html.slim:63](https://github.com/epologee/danger.systems/blob/3107fc14f979cca4eb0d9974a149ca30b7e706a8/static/source/guides/getting_started.html.slim#L63) should be changed as well:

> In order to get the most out of Danger, we recommend giving her the ability to post comments in your code review. This is a regular GitHub account, depending on whether you are working on a private or public project you will want to give different levels of access to this bot. You are allowed to have [one bot per GitHub account][github_bots].