### PR TITLE
Fixes text selection bug in reference page.

### DIFF
--- a/static/source/_plugin_doc.slim
+++ b/static/source/_plugin_doc.slim
@@ -17,6 +17,10 @@ ruby:
     string_params
   end
 
+  def method_name(meth)
+    meth["name"] + ' '
+  end
+
   plugins = JSON.parse(File.read("../plugins-search-generated.json"))
   gem_for_plugin = plugins["plugins"].find { |gem_plugin| gem_plugin["gem"] == plugin["gem"] } 
 
@@ -41,7 +45,7 @@ article.scope_code
     - for method in plugin["methods"]
       .fake_code
          == markdown_h(method["body_md"])
-      code == method["name"] + span_params(method) + span_return(method)
+      code == method_name(method) + span_params(method) + span_return(method)
 
 article.scope_code
   h3 Examples


### PR DESCRIPTION
Fixes #59.

This was far easier than I had expected. There was no space between the two divs, so the browser was interpreting the double-click as selecting the whole word (which was the whole line, since there were no spaces). 

This doesn't affect the display, cuz HTML gobbles extra whitespace anyway. 

![screen shot 2016-07-28 at 10 53 34 am](https://cloud.githubusercontent.com/assets/498212/17217229/94bf09fa-54b1-11e6-883f-28b63beb7d29.png)
