### PR TITLE
Consolidate all 3 markdown renderers' settings - fixes #54

### DIFF
--- a/static/config.rb
+++ b/static/config.rb
@@ -20,10 +20,18 @@ set :css_dir, 'stylesheets'
 set :js_dir, 'javascripts'
 set :images_dir, 'images'
 
+$md_settings = {
+  autolink: true,
+  space_after_headers: true,
+  no_intra_emphasis: true,
+  tables: true, with_toc_data: true,
+  fenced_code_blocks: true,
+  smartypants: true
+}
+
+Slim::Embedded.options[:markdown] = $md_settings
 set :markdown_engine, :redcarpet
-set :markdown, autolink: true, space_after_headers: true,
-               no_intra_emphasis: true, tables: true, with_toc_data: true,
-               fenced_code_blocks: true, smartypants: true
+set :markdown, $md_settings
 
 require 'lib/html_helpers.rb'
 helpers HTMLHelpers

--- a/static/lib/html_helpers.rb
+++ b/static/lib/html_helpers.rb
@@ -9,7 +9,7 @@ module HTMLHelpers
   # @return [String] HTML
   #
   def markdown_h(input)
-    @markdown_instance ||= Redcarpet::Markdown.new(Class.new(Redcarpet::Render::HTML), autolink: true, space_after_headers: true, no_intra_emphasis: true,fenced_code_blocks: true, smartypants: true)
+    @markdown_instance ||= Redcarpet::Markdown.new(Class.new(Redcarpet::Render::HTML), $md_settings)
     # TODO: experimental
     @markdown_instance.render(capitalize_first_letter(input))
   end

--- a/static/source/guides/getting_started.html.slim
+++ b/static/source/guides/getting_started.html.slim
@@ -76,7 +76,7 @@ section.guide
 
       We recommend giving access to the whole `repo` scope, and it's children.
 
-      #### Continuous Integration
+      ### Continuous Integration
 
       Continuous Integration is the process of regularly running tests, and generating metrics for a project. It is where you can ensure that the code you are submitting for review is passing on all of the tests. You commonly see this as green, or red dots inside GitHub pull requests.
 


### PR DESCRIPTION
See #68 for a screenshot of the before - roughly no markers for the URL.

![screen shot 2016-07-30 at 6 18 21 pm](https://cloud.githubusercontent.com/assets/49038/17273421/037bfee4-5682-11e6-9389-573e642f0938.png)
