### PR TITLE
add target="_blank" to external links

### DIFF
--- a/static/config.rb
+++ b/static/config.rb
@@ -16,6 +16,9 @@ end
 require 'lib/add_links_to_headers.rb'
 activate :add_links_to_headers
 
+require 'lib/add_target_to_links.rb'
+activate :add_target_to_links
+
 set :css_dir, 'stylesheets'
 set :js_dir, 'javascripts'
 set :images_dir, 'images'

--- a/static/lib/add_target_to_links.rb
+++ b/static/lib/add_target_to_links.rb
@@ -1,0 +1,47 @@
+# Require core library
+require 'cgi'
+require 'middleman-core'
+require 'nokogiri'
+
+# we want each link linking to an external page open in a new window by setting
+# the target
+
+module Middleman
+  class AddTargetToLinks < Middleman::Extension
+    def initialize(app, options_hash = {}, &block)
+      super
+      app.after_render do |body, path, _locs, template_class|
+        # we get multiple render calls due to markdown / slim doing their thing
+        #
+        if (template_class.to_s.index 'Slim') != nil || (path.to_s.index 'templates') != nil
+          doc = Nokogiri::HTML(body)
+          nodes = doc.css('a')
+
+          if nodes.count > 0
+            nodes.each do |link|
+              link['target'] = '_blank' if !has_target(link) && is_external(link)
+            end
+
+            body = doc.to_s
+          end
+        end
+
+        body
+      end
+    end
+
+    private
+
+    def has_target(link)
+      link['target'].present?
+    end
+
+    def is_external(link)
+      link['href'].to_s.include?('http')
+    end
+  end
+end
+
+::Middleman::Extensions.register(:add_target_to_links) do
+  Middleman::AddTargetToLinks
+end

--- a/static/source/index.html.slim
+++ b/static/source/index.html.slim
@@ -165,7 +165,7 @@ javascript:
        var toGithubLink = function(ref) {
            var branch = (ref.indexOf("#") > -1) ? ref.split("#")[1] : "master"
            var repo = ref.split("#")[0]
-           return "<a href='https://github.com/" + repo + "/blob/" + branch +"/Dangerfile'>" + repo + "</a>"
+           return "<a href='https://github.com/" + repo + "/blob/" + branch +"/Dangerfile' target='_blank'>" + repo + "</a>"
         }
         var showArray = function(array) {
           if (!array) { return false }


### PR DESCRIPTION
Whenever a link has a href to an external site, add the target to open
it in a new window/tab. See issue #52 

- [x] Add target to external links
- [x] Ignore when there is already a target set
- [x] Figure out why this doesnt work for the links in the "For example" section

#### Example:
See [link here](https://github.com/dbgrandi/danger-prose/blob/master/lib/danger_plugin.rb#L5) which (ok it's confusing because it's unrendered markdown) does not have a `target="_blank"`.

Will now render with target:
<img width="646" alt="bildschirmfoto 2016-08-10 um 12 11 48" src="https://cloud.githubusercontent.com/assets/68024/17550208/274f25d8-5ef4-11e6-89f8-0777935a8664.png">
