### PR TITLE
Use the diff to get the before and after

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -4,13 +4,17 @@
 # to lint the documentation, and to ensure that some effort has been put in.
 
 require 'json'
-current_plugins = JSON.parse(`git show master:plugins.json`)
-pr_plugins = JSON.parse(File.read("plugins.json"))
 
-new_plugins = current_plugins - pr_plugins
-new_plugins.each do |plugin|
-  overview = `bundle exec danger plugins readme #{plugin}`
-  markdown "### Failed to parse #{plugin}" if $0 != 0
-  markdown overview
-  markdown "\n\n ---\n"
+diff = git.diff_for_file("plugins.json")
+if diff
+  current_plugins = JSON.parse(diff.blob(:dst).contents)
+  pr_plugins = JSON.parse(diff.blob(:src).contents)
+
+  new_plugins = current_plugins - pr_plugins
+  new_plugins.each do |plugin|
+    overview = `bundle exec danger plugins readme #{plugin}`
+    markdown "### Failed to parse #{plugin}" if $0 != 0
+    markdown overview
+    markdown "\n\n ---\n"
+  end
 end


### PR DESCRIPTION
Uses the git diff to pull off a before / after for the plugins.json - this means that the forks issue won't be a problem. /cc @dbgrandi  - this is how we could build the DSL for comparing a changed file.

