### PR TITLE
Add info about local Danger environment variables to Troubleshooting

### DIFF
--- a/static/source/guides/troubleshooting.html.md
+++ b/static/source/guides/troubleshooting.html.md
@@ -11,7 +11,7 @@ OK, so, you can use `bundle exec danger local` to have Danger run the last merge
 
 This will run the Danger environment locally, making it possible to iterate and verify syntax etc.
 
-Make sure to setup the `DANGER_GITHUB_API_TOKEN` and optionally `DANGER_GITHUB_HOST` environment values before attempting to run `local`. If you are trying to access an Enterprise GitHub instance, `DANGER_GITHUB_HOST` must be set.
+Make sure to setup the `DANGER_GITHUB_API_TOKEN` environment variable before attempting to run `local`. If you are trying to access an Enterprise Github instance, `DANGER_GITHUB_HOST` and `DANGER_GITHUB_API_HOST` must be set.
 
 ### I want to be a Danger Wizard
 

--- a/static/source/guides/troubleshooting.html.md
+++ b/static/source/guides/troubleshooting.html.md
@@ -11,6 +11,8 @@ OK, so, you can use `bundle exec danger local` to have Danger run the last merge
 
 This will run the Danger environment locally, making it possible to iterate and verify syntax etc.
 
+Make sure to setup the `DANGER_GITHUB_API_TOKEN` and optionally `DANGER_GITHUB_HOST` environment values before attempting to run `local`. If you are trying to access an Enterprise GitHub instance, `DANGER_GITHUB_HOST` must be set.
+
 ### I want to be a Danger Wizard
 
 ![](http://i.imgur.com/QCwKwKQ.gif)


### PR DESCRIPTION
This is why I was getting an error trying to run `local`. Totally forgot to add that.