### PR TITLE
[ENV] Update instructions for API variables

### DIFF
--- a/static/source/guides/faq.html.md
+++ b/static/source/guides/faq.html.md
@@ -28,12 +28,20 @@ There's a [Work in Progress PR](https://github.com/danger/danger/pull/299) - the
 You can work with GitHub Enterprise by setting 2 environment variables:
 
 - `DANGER_GITHUB_HOST` to the host that GitHub is running on.
-- `DANGER_GITHUB_API_HOST` to the host that the GitHub Enterprise API is reachable on.
+- `DANGER_GITHUB_API_HOST` to the host that the GitHub Enterprise API is reachable on. After 3.0
+  the preferred name for this variable is `DANGER_GITHUB_API_BASE_URL`, however `DANGER_GITHUB_API_HOST`
+  will still work.
 
 This could look like:
 
 ```
 DANGER_GITHUB_API_HOST=https://git.corp.evilcorp.com/api/v3 DANGER_GITHUB_HOST=git.corp.evilcorp.com bundle exec danger
+```
+
+and after 3.0:
+
+```
+DANGER_GITHUB_API_BASE_URL=https://git.corp.evilcorp.com/api/v3 DANGER_GITHUB_HOST=git.corp.evilcorp.com bundle exec danger
 ```
 
 #### I want to run Danger across multiple repos

--- a/static/source/guides/troubleshooting.html.md
+++ b/static/source/guides/troubleshooting.html.md
@@ -11,7 +11,7 @@ OK, so, you can use `bundle exec danger local` to have Danger run the last merge
 
 This will run the Danger environment locally, making it possible to iterate and verify syntax etc.
 
-For closed source projects, make sure to setup the `DANGER_GITHUB_API_TOKEN` environment variable before attempting to run `local`.  If you are trying to access an Enterprise Github instance, `DANGER_GITHUB_HOST` and `DANGER_GITHUB_API_HOST` must be set.
+For closed source projects, make sure to setup the `DANGER_GITHUB_API_TOKEN` environment variable before attempting to run `local`.  If you are trying to access an Enterprise Github instance, `DANGER_GITHUB_HOST` and `DANGER_GITHUB_API_HOST`(`DANGER_GITHUB_API_BASE_URL` after 3.0)  must be set.
 
 ### I want to only run Danger for internal branches
 


### PR DESCRIPTION
Updated to reflect changes in danger/danger `d5844bab25cb37d9282a6c167596e137ebc82015`.

Might wanna hold off on merging this since 3.0 is released?