### PR TITLE
Added danger.changelog, https://github.com/dblock/danger-changelog.

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -8,5 +8,6 @@
    "danger-junit_results",
    "danger-podliblint",
    "danger-simplecov_json",
-   "danger-commit_lint"
+   "danger-commit_lint",
+   "danger-changelog"
 ]


### PR DESCRIPTION
This plugin is OCD about your CHANGELOG format.