### PR TITLE
Remove krausefx from header

### DIFF
--- a/static/source/layouts/layout.slim
+++ b/static/source/layouts/layout.slim
@@ -32,7 +32,7 @@ html
   body class=page_classes
 
     - if is_home
-      code.byline a project from <a target="_blank" href="http://orta.io">orta therox</a><br/>and <a target="_blank" href="https://krausefx.com">felix krause</a>.
+      code.byline a project from <a target="_blank" href="http://orta.io">orta therox</a><br/>and <a target="_blank" href="https://github.com/danger/danger/graphs/contributors">other core contributors</a>.
 
     header class=(is_home ? 'title' : 'title small')
 
@@ -56,7 +56,7 @@ html
 
       h2.reduced_top_margin
         span == current_page.data["subtitle"]
-        code.byline.inline a project from <a target="_blank" href="http://orta.io">orta therox</a> and <a target="_blank" href="https://krausefx.com">felix krause</a>.
+        code.byline.inline a project from <a target="_blank" href="http://orta.io">orta therox</a> and <a target="_blank" href="https://github.com/danger/danger/graphs/contributors">other core contributors</a>.
 
     == yield
 


### PR DESCRIPTION
Unfortunately I didn’t have enough time to work on danger over the last few weeks, so I feel like I don’t deserve being on the header of the website anymore, but put a link to all danger contributors instead. While https://github.com/danger/danger/graphs/contributors only lists contributors of the main repo, it’s a good start before we build something similar that CocoaPods has.
Let me know if the wording is okay, or if you’d like it to be changed
